### PR TITLE
reenabled tls

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ description: A Gradle Build Cache server with MinIO backend for Theia IDE deploy
 type: application
 
 # Chart version - bump for breaking changes
-version: 0.2.1
+version: 0.2.2
 
 # Application version - matches the cache server version
 appVersion: "0.1.0"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -12,6 +12,12 @@ data:
       port: 8080
       read_timeout: 30s
       write_timeout: 120s
+      {{- if .Values.tls.enabled }}
+      tls:
+        enabled: true 
+        cert_file: /tls/tls.crt
+        key_file: /tls/tls.key
+      {{- end}}
 
     storage:
       endpoint: "{{ .Release.Name }}-minio:9000"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -105,8 +105,18 @@ spec:
             - name: config
               mountPath: /etc/gradle-cache
               readOnly: true
+            {{- if .Values.tls.enabled }}
+            - name: tls-certs
+              mountPath: /etc/certs
+              readOnly: true
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ .Release.Name }}-config
+        {{- if .Values.tls.enabled }}
+        - name: tls-certs
+          secret:
+            secretName: {{ .Values.tls.secretName }}
+        {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,3 +40,9 @@ resources:
     limits:
       memory: "2Gi"
       cpu: "1000m"
+
+tls:
+  # Enable TLS for the cache server
+  enabled: false
+  # TLS secret name (if TLS is enabled)
+  secretName: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TLS configuration capability to the Helm chart. Users can now enable TLS and specify certificate secrets. When enabled, TLS certificates from Kubernetes secrets are automatically mounted to the deployment and included in server configuration. TLS is disabled by default to maintain backward compatibility.

* **Chores**
  * Bumped Helm chart version to 0.2.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->